### PR TITLE
widen focus ring mask to draw outside the border

### DIFF
--- a/FlatButton/FlatButton.swift
+++ b/FlatButton/FlatButton.swift
@@ -373,7 +373,11 @@ open class FlatButton: NSButton, CALayerDelegate {
     }
     
     override open func draw(_ dirtyRect: NSRect) {
-        
+        // nop
+    }
+    
+    override open func drawFocusRingMask() {
+        self.bounds.fill()
     }
     
     override open func layout() {
@@ -384,7 +388,5 @@ open class FlatButton: NSButton, CALayerDelegate {
     override open func updateLayer() {
         super.updateLayer()
     }
-    
-    
 }
 


### PR DESCRIPTION
Before this, tabbing between `FlatButton`s drew the focus ring mask (the selection outline) a bit too much on the inside of the buttons.

Before:

![before](https://user-images.githubusercontent.com/59080/36034957-e65a7c54-0db5-11e8-812d-15e9f6ca40ab.png)

After:

![2 after](https://user-images.githubusercontent.com/59080/36034959-e68a5730-0db5-11e8-9899-0d00514699f3.png)
